### PR TITLE
Fix issue with getParticipantCount

### DIFF
--- a/application/src/Entity/Meeting.php
+++ b/application/src/Entity/Meeting.php
@@ -413,10 +413,7 @@ class Meeting
 
     public function getParticipantCount(): int
     {
-        return count($this->getAttendees()->filter(function($attendee): bool
-        {
-            return $attendee->isParticipant();
-        }));
+        return count($this->getAttendees());
     }
 
     public function getModeratorCount(): int


### PR DESCRIPTION
* The participantCount returned by BBB server is the total MODERATOR +
VIEWER (i.e. the number of attendees), not just the number of VIEWER